### PR TITLE
chore(ios): rebrand bundle ID to com.shivshankartiwari.ignitekit

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,41 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <uses-permission android:name="android.permission.INTERNET" />
-
-    <application
-      android:name=".MainApplication"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      android:supportsRtl="true">
-      <meta-data
-        android:name="expo.modules.updates.ENABLED"
-        android:value="true" />
-      <meta-data
-        android:name="expo.modules.updates.EXPO_RUNTIME_VERSION"
-        android:value="1.0.0" />
-      <meta-data
-        android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH"
-        android:value="ALWAYS" />
-      <meta-data
-        android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS"
-        android:value="0" />
-      <meta-data
-        android:name="expo.modules.updates.EXPO_UPDATE_URL"
-        android:value="https://u.expo.dev/81e7f11f-c57a-420e-ae2a-b564c882828a" />
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize"
-        android:exported="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-    </application>
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true">
+    <meta-data android:name="expo.modules.updates.ENABLED" android:value="true"/>
+    <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/81e7f11f-c57a-420e-ae2a-b564c882828a"/>
+    <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+  </application>
 </manifest>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="app_name">ReactNativeIgniteKit</string>
+  <string name="app_name">ReactNativeIgniteKit</string>
+  <string name="expo_runtime_version">1.0.0</string>
 </resources>

--- a/app.config.js
+++ b/app.config.js
@@ -61,6 +61,6 @@ module.exports = {
     package: 'com.shivshankartiwari.reactnativeignitekit',
   },
   ios: {
-    bundleIdentifier: 'com.educatorslabs.ignitekit',
+    bundleIdentifier: 'com.shivshankartiwari.ignitekit',
   },
 };

--- a/eas.json
+++ b/eas.json
@@ -62,7 +62,7 @@
       },
       "ios": {
         "ascAppId": "6761337270",
-        "bundleIdentifier": "com.educatorslabs.ignitekit"
+        "bundleIdentifier": "com.shivshankartiwari.ignitekit"
       }
     },
     "staging": {
@@ -73,7 +73,7 @@
       },
       "ios": {
         "ascAppId": "6761337270",
-        "bundleIdentifier": "com.educatorslabs.ignitekit"
+        "bundleIdentifier": "com.shivshankartiwari.ignitekit"
       }
     },
     "production": {
@@ -84,7 +84,7 @@
       },
       "ios": {
         "ascAppId": "6761337270",
-        "bundleIdentifier": "com.educatorslabs.ignitekit"
+        "bundleIdentifier": "com.shivshankartiwari.ignitekit"
       }
     }
   }

--- a/ios/IgniteKit.xcodeproj/project.pbxproj
+++ b/ios/IgniteKit.xcodeproj/project.pbxproj
@@ -1036,7 +1036,7 @@
 					"$(inherited)",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IgniteKit.app/IgniteKit";
@@ -1063,7 +1063,7 @@
 					"$(inherited)",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/IgniteKit.app/IgniteKit";
@@ -1093,7 +1093,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = IgniteKit;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1122,7 +1122,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = IgniteKit;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1154,7 +1154,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1187,7 +1187,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1220,7 +1220,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1253,7 +1253,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1284,7 +1284,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1314,7 +1314,7 @@
 					"-lc++",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
-				PRODUCT_BUNDLE_IDENTIFIER = com.educatorslabs.ignitekit;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shivshankartiwari.ignitekit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "screenshots:help": "cat docs/SCREENSHOTS.md",
     "screenshots:1:build": "xcodebuild -workspace ios/IgniteKit.xcworkspace -scheme 'IgniteKit staging' -configuration Release -sdk iphonesimulator -derivedDataPath ios/simulator-build CODE_SIGNING_ALLOWED=NO | grep -E 'error:|Build succeeded|Build FAILED'",
     "screenshots:2:capture": "bash scripts/capture-screenshots.sh",
-    "screenshots:3:upload:ios": "[ -f ./asc-api-key.json ] || (echo 'Error: asc-api-key.json not found. See docs/SCREENSHOTS.md.' && exit 1) && bundle exec fastlane run deliver api_key_path:./asc-api-key.json app_identifier:com.educatorslabs.ignitekit screenshots_path:./screenshots/ios skip_binary_upload:true skip_metadata:true overwrite_screenshots:true ignore_language_directory_validation:true force:true precheck_include_in_app_purchases:false",
+    "screenshots:3:upload:ios": "[ -f ./asc-api-key.json ] || (echo 'Error: asc-api-key.json not found. See docs/SCREENSHOTS.md.' && exit 1) && bundle exec fastlane run deliver api_key_path:./asc-api-key.json app_identifier:com.shivshankartiwari.ignitekit screenshots_path:./screenshots/ios skip_binary_upload:true skip_metadata:true overwrite_screenshots:true ignore_language_directory_validation:true force:true precheck_include_in_app_purchases:false",
     "screenshots:3:upload:android": "bundle exec fastlane run supply --skip_upload_apk --skip_upload_aab --skip_upload_metadata --sync_image_upload true",
     "screenshots:all": "yarn screenshots:1:build && yarn screenshots:2:capture && yarn screenshots:3:upload:ios"
   },


### PR DESCRIPTION
## What

Re-points the **iOS app identity** from `com.educatorslabs.ignitekit` → **`com.shivshankartiwari.ignitekit`** so the app ships under my own Apple Developer account (domain `shivshankartiwari.com`).

## Why

I now have my own Apple Developer account and want to publish IgniteKit to the App Store under it. The iOS native project and EAS config must agree on the bundle identifier or signing/submission breaks.

## Changes

| File | Change |
|------|--------|
| `ios/IgniteKit.xcodeproj/project.pbxproj` | All 10 `PRODUCT_BUNDLE_IDENTIFIER` entries (every iOS scheme) |
| `app.config.js` | `ios.bundleIdentifier` (EAS credentials/metadata) |
| `eas.json` | `bundleIdentifier` in dev/staging/prod submit profiles |
| `package.json` | fastlane `deliver` `app_identifier` in screenshot upload script |
| `android/app/src/main/AndroidManifest.xml` | OTA `EXPO_RUNTIME_VERSION` now references `@string/expo_runtime_version`; trailing newline restored |
| `android/app/src/main/res/values/strings.xml` | Adds `expo_runtime_version` string (single source of truth); trailing newline restored |

## Notes / follow-ups (not in this PR)

- The old `AuthKey_*.p8` / `asc-api-key.json` belong to the `educatorslabs` account and must be replaced with a fresh **App Store Connect API key** before `eas submit`.
- A new App Store Connect app record + numeric `ascAppId` (replacing `6761337270`) is still needed.
- `store.config.json` marketing/support/privacy URLs still point at `educatorslabs.com` — to be updated to `shivshankartiwari.com` at the metadata step.

## Verification

- `grep -c com.shivshankartiwari.ignitekit ios/IgniteKit.xcodeproj/project.pbxproj` → `10`
- No `educatorslabs` bundle-ID references remain (only the metadata URLs noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)